### PR TITLE
Added XSLTs and adjustments to support the Oral Histories SP

### DIFF
--- a/conf/schema.xml
+++ b/conf/schema.xml
@@ -327,6 +327,9 @@
    <dynamicField name="*_mdt" type="date"    indexed="true"  stored="true" multiValued="true"/>
    <dynamicField name="*_et" type="edgedText" indexed="true" stored="true" multiValued="true"/>
    <dynamicField name="*_mlt" type="mappedLowerText" indexed="true" stored="true" multiValued='false'/>
+   <!-- begin: islandora_solution_pack_oralhistories setup -->
+   <dynamicField name="or_*" type="text" indexed="true" stored="true" multiValued="true"/>
+   <!-- end: islandora_solution_pack_oralhistories setup -->
    <!-- uncomment the following to ignore any fields that don't already match an existing
         field name or dynamic field, rather than reporting them as an error.
         alternately, change the type="ignored" to some other type e.g. "text" if you want

--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -229,10 +229,6 @@
                https://github.com/fcrepo/gsearch/blob/master/FedoraGenericSearch/src/java/dk/defxws/fedoragsearch/server/TransformerToText.java#L185-L200
           -->
 
-          <!-- begin: islandora_solution_pack_oralhistories setup -->
-          <xsl:when test="@CONTROL_GROUP='M' and @ID='TRANSCRIPT' and foxml:datastreamVersion[last()][@MIMETYPE='text/vtt']">  </xsl:when>
-          <!-- end: islandora_solution_pack_oralhistories setup -->
-
           <xsl:when test="@CONTROL_GROUP='M' and foxml:datastreamVersion[last() and not(starts-with(@MIMETYPE, 'image') or starts-with(@MIMETYPE, 'audio') or starts-with(@MIMETYPE, 'video') or @MIMETYPE = 'application/pdf')]">
             <!-- TODO: should do something about mime type filtering
               text/plain should use the getDatastreamText extension because document will only work for xml docs

--- a/foxmlToSolr.xslt
+++ b/foxmlToSolr.xslt
@@ -109,6 +109,10 @@
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/slurp_all_chemicalML_to_solr.xslt"/>
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/library/traverse-graph.xslt"/>
   <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/hierarchy.xslt"/>
+  <!-- begin: islandora_solution_pack_oralhistories setup -->
+  <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/or_transcript_solr.xslt"/>
+  <xsl:include href="/usr/local/fedora/tomcat/webapps/fedoragsearch/WEB-INF/classes/fgsconfigFinal/index/FgsIndex/islandora_transforms/vtt_solr.xslt"/>
+  <!-- end: islandora_solution_pack_oralhistories setup -->
 
   <!-- Decide which objects to modify the index of -->
   <xsl:template match="/">
@@ -224,6 +228,11 @@
                handle the mimetypes supported by the "getDatastreamText" call:
                https://github.com/fcrepo/gsearch/blob/master/FedoraGenericSearch/src/java/dk/defxws/fedoragsearch/server/TransformerToText.java#L185-L200
           -->
+
+          <!-- begin: islandora_solution_pack_oralhistories setup -->
+          <xsl:when test="@CONTROL_GROUP='M' and @ID='TRANSCRIPT' and foxml:datastreamVersion[last()][@MIMETYPE='text/vtt']">  </xsl:when>
+          <!-- end: islandora_solution_pack_oralhistories setup -->
+
           <xsl:when test="@CONTROL_GROUP='M' and foxml:datastreamVersion[last() and not(starts-with(@MIMETYPE, 'image') or starts-with(@MIMETYPE, 'audio') or starts-with(@MIMETYPE, 'video') or @MIMETYPE = 'application/pdf')]">
             <!-- TODO: should do something about mime type filtering
               text/plain should use the getDatastreamText extension because document will only work for xml docs
@@ -259,7 +268,7 @@
         reindexing all the descendents whenever indexing an object
         (updating a collection label would be fairly expensive if we blindly
         reindexed). -->
-      
+
       <xsl:variable name="ancestors">
         <xsl:call-template name="get-ancestors">
           <xsl:with-param name="PID" select="$PID" />

--- a/islandora_transforms/or_transcript_solr.xslt
+++ b/islandora_transforms/or_transcript_solr.xslt
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- ORALHISTORIES TRANSCRIPT -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:dcterms="http://purl.org/dc/terms/">
-
-    <xsl:template match="foxml:datastream[@ID='TRANSCRIPT']/foxml:datastreamVersion[last()]" name="index_TRANSCRIPT">
+    <xsl:template match="foxml:datastream[@ID='TRANSCRIPT']/foxml:datastreamVersion[last()][not(@MIMETYPE='text/vtt')]" name="index_TRANSCRIPT">
         <xsl:param name="content"/>
         <xsl:param name="prefix">or_</xsl:param>
         <xsl:param name="solespeaker" select="$content//solespeaker"></xsl:param>
@@ -21,12 +20,12 @@
                         <xsl:value-of select="$solespeaker"/>
                     </field>
                 </xsl:if>
-                <xsl:apply-templates>
+                <xsl:apply-templates mode='slurping_oh_transform'>
                     <xsl:with-param name="prefix" select="$prefix"/>
                 </xsl:apply-templates>
             </xsl:for-each>
     </xsl:template>
-    <xsl:template match="//cue/*">
+    <xsl:template match="//cue/*" mode='slurping_oh_transform'>
         <xsl:param name="prefix" />
         <xsl:for-each select=".">
             <field>

--- a/islandora_transforms/or_transcript_solr.xslt
+++ b/islandora_transforms/or_transcript_solr.xslt
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ORALHISTORIES TRANSCRIPT -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:dcterms="http://purl.org/dc/terms/">
+
+    <xsl:template match="foxml:datastream[@ID='TRANSCRIPT']/foxml:datastreamVersion[last()]" name="index_TRANSCRIPT">
+        <xsl:param name="content"/>
+        <xsl:param name="prefix">or_</xsl:param>
+        <xsl:param name="solespeaker" select="$content//solespeaker"></xsl:param>
+        <xsl:for-each select="$content//cue">
+                <field>
+                    <xsl:attribute name="name">
+                        <xsl:value-of select="concat($prefix, 'cue_id')"/>
+                    </xsl:attribute>
+                    <xsl:value-of select="position()"/>
+                </field>
+                <xsl:if test="$content//solespeaker">
+                    <field>
+                        <xsl:attribute name="name">
+                            <xsl:value-of select="concat($prefix, 'speaker')"/>
+                        </xsl:attribute>
+                        <xsl:value-of select="$solespeaker"/>
+                    </field>
+                </xsl:if>
+                <xsl:apply-templates>
+                    <xsl:with-param name="prefix" select="$prefix"/>
+                </xsl:apply-templates>
+            </xsl:for-each>
+    </xsl:template>
+    <xsl:template match="//cue/*">
+        <xsl:param name="prefix" />
+        <xsl:for-each select=".">
+            <field>
+                <xsl:attribute name="name">
+                    <xsl:value-of select="concat($prefix, local-name())"/>
+                </xsl:attribute>
+                <xsl:value-of select="."/>
+            </field>
+        </xsl:for-each>
+    </xsl:template>
+</xsl:stylesheet>

--- a/islandora_transforms/vtt_solr.xslt
+++ b/islandora_transforms/vtt_solr.xslt
@@ -11,12 +11,12 @@
         </xsl:attribute>
         <xsl:value-of select="position()"/>
       </field>
-      <xsl:apply-templates>
+      <xsl:apply-templates mode='slurping_vtt'>
         <xsl:with-param name="prefix" select="$prefix"/>
       </xsl:apply-templates>
     </xsl:for-each>
   </xsl:template>
-  <xsl:template match="//cue/*">
+  <xsl:template match="//cue/*" mode='slurping_vtt'>
     <xsl:param name="prefix" />
     <xsl:for-each select=".">
       <field>

--- a/islandora_transforms/vtt_solr.xslt
+++ b/islandora_transforms/vtt_solr.xslt
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- ORALHISTORIES TRANSCRIPT -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:foxml="info:fedora/fedora-system:def/foxml#" xmlns:dcterms="http://purl.org/dc/terms/">
+  <xsl:template match="foxml:datastream[contains(@ID, 'INDEXMEDIATRACK') or contains(@ID, 'INDEXTRANSCRIPT')]/foxml:datastreamVersion[last()]" name="index_VTT">
+    <xsl:param name="content"/>
+    <xsl:param name="prefix">vtt_</xsl:param>
+    <xsl:for-each select="$content//cue">
+      <field>
+        <xsl:attribute name="name">
+          <xsl:value-of select="concat($prefix, 'cue_id')"/>
+        </xsl:attribute>
+        <xsl:value-of select="position()"/>
+      </field>
+      <xsl:apply-templates>
+        <xsl:with-param name="prefix" select="$prefix"/>
+      </xsl:apply-templates>
+    </xsl:for-each>
+  </xsl:template>
+  <xsl:template match="//cue/*">
+    <xsl:param name="prefix" />
+    <xsl:for-each select=".">
+      <field>
+        <xsl:attribute name="name">
+          <xsl:value-of select="concat($prefix, local-name())"/>
+        </xsl:attribute>
+        <xsl:value-of select="."/>
+      </field>
+    </xsl:for-each>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
Client is now using the [Oral Histories SP](https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/) and would like their TRANSCRIPT datastreams to be indexed in solr.

Followed this guide: https://github.com/Islandora-Labs/islandora_solution_pack_oralhistories/wiki/Configuration:--Basic-Indexing-of-transcripts-in-Solr