### PR TITLE
Patching custom PHS fields

### DIFF
--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -28,7 +28,7 @@
       <xsl:with-param name="pid" select="../../@PID"/>
       <xsl:with-param name="datastream" select="../@ID"/>
     </xsl:apply-templates>
-    
+
     <xsl:apply-templates mode="slurping_MODS_phs" select="$content//mods:mods[1]">
       <xsl:with-param name="prefix" select="$prefix"/>
       <xsl:with-param name="suffix" select="$suffix"/>
@@ -36,20 +36,20 @@
       <xsl:with-param name="datastream" select="../@ID"/>
     </xsl:apply-templates>
   </xsl:template>
-  
+
   <!-- PHS custom context building -->
   <xsl:template match="*" mode="slurping_MODS_phs">
     <xsl:param name="prefix"/>
     <xsl:param name="suffix"/>
-    <xsl:variable name="this_prefix">                                                                                                                 
-      <xsl:value-of select="concat($prefix, 'mods_')"/>                                                                                           
-    </xsl:variable> 
+    <xsl:variable name="this_prefix">
+      <xsl:value-of select="concat($prefix, local-name(), '_')"/>
+    </xsl:variable>
     <xsl:apply-templates mode="slurping_MODS_phs">
       <xsl:with-param name="prefix" select="$this_prefix"/>
       <xsl:with-param name="suffix" select="$suffix"/>
     </xsl:apply-templates>
   </xsl:template>
-  
+
   <!-- PHS Custom name field for name/namePart and role/roleTerm -->
   <xsl:template mode="slurping_MODS_phs" match="mods:name">
     <xsl:param name="prefix"/>
@@ -102,8 +102,8 @@
         </xsl:call-template>
       </xsl:if>
     </xsl:for-each>
-    
-    <xsl:for-each select="mods:location/mods:url">     
+
+    <xsl:for-each select="mods:location/mods:url">
       <xsl:if test="not(normalize-space(.)='')">
         <xsl:variable name="this_prefix">
           <xsl:value-of select="concat($prefix, 'relatedItem_url_phs_')"/>

--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -65,9 +65,8 @@
       </xsl:variable>
       <xsl:variable name="name_value">
         <xsl:value-of select="normalize-space(mods:namePart[1])"/>
-        <xsl:if test="not(normalize-space(mods:role[1]/mods:roleTerm)='') and name(..) != 'subject'">
-          (<xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>)
-        </xsl:if>
+        <xsl:if test="not(normalize-space(mods:role[1]/mods:roleTerm)='') and name(..) != 'subject'"
+          > (<xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>)</xsl:if>
       </xsl:variable>
       <xsl:variable name="this_prefix">
         <xsl:value-of select="concat($prefix, $field_name)"/>

--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -59,14 +59,15 @@
     <xsl:if test="not(normalize-space(mods:namePart[1])='')">
       <xsl:variable name="field_name">
         <xsl:choose>
-          <xsl:when test="name(..) = 'subject'">subject_name_phs_</xsl:when>
+          <xsl:when test="name(..) = 'subject'">name_phs_</xsl:when>
           <xsl:otherwise>name_role_phs_</xsl:otherwise>
         </xsl:choose>
       </xsl:variable>
       <xsl:variable name="name_value">
         <xsl:value-of select="normalize-space(mods:namePart[1])"/>
-        <xsl:if test="not(normalize-space(mods:role[1]/mods:roleTerm)='') and name(..) != 'subject'"
-          > (<xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>)</xsl:if>
+        <xsl:if test="not(normalize-space(mods:role[1]/mods:roleTerm)='') and name(..) != 'subject'">
+          (<xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>)
+        </xsl:if>
       </xsl:variable>
       <xsl:variable name="this_prefix">
         <xsl:value-of select="concat($prefix, $field_name)"/>


### PR DESCRIPTION
PHS has 4 custom fields:

`mods_subject_name_phs_ms`
`mods_name_role_phs_ms`
`mods_relatedItem_title_phs_ms`
`mods_relatedItem_url_phs_ms`

With the recent changes, the prefixes have been coming out strange. Ex: mods_mods_ or mods_subject_subject_ etc...

This pull aims to mitigate these issues.