### PR TITLE
Handle MODS subjects and names with split subfields

### DIFF
--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -14,17 +14,6 @@
   <!-- HashSet to track single-valued fields. -->
   <xsl:variable name="single_valued_hashset" select="java:java.util.HashSet.new()"/>
 
-  <xsl:template match="//mods:mods">
-    <fields>
-      <xsl:apply-templates mode="slurping_MODS" select=".">
-        <xsl:with-param name="suffix" select="'ms'"/>
-      </xsl:apply-templates>
-
-      <xsl:apply-templates mode="slurping_MODS_phs" select=".">
-        <xsl:with-param name="suffix" select="'ms'"/>
-      </xsl:apply-templates>
-    </fields>
-  </xsl:template>
 
   <xsl:template match="foxml:datastream[@ID='MODS']/foxml:datastreamVersion[last()]" name="index_MODS">
     <xsl:param name="content"/>

--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -14,6 +14,18 @@
   <!-- HashSet to track single-valued fields. -->
   <xsl:variable name="single_valued_hashset" select="java:java.util.HashSet.new()"/>
 
+  <xsl:template match="//mods:mods">
+    <fields>
+      <xsl:apply-templates mode="slurping_MODS" select=".">
+        <xsl:with-param name="suffix" select="'ms'"/>
+      </xsl:apply-templates>
+
+      <xsl:apply-templates mode="slurping_MODS_phs" select=".">
+        <xsl:with-param name="suffix" select="'ms'"/>
+      </xsl:apply-templates>
+    </fields>
+  </xsl:template>
+
   <xsl:template match="foxml:datastream[@ID='MODS']/foxml:datastreamVersion[last()]" name="index_MODS">
     <xsl:param name="content"/>
     <xsl:param name="prefix"></xsl:param>
@@ -64,9 +76,18 @@
         </xsl:choose>
       </xsl:variable>
       <xsl:variable name="name_value">
-        <xsl:value-of select="normalize-space(mods:namePart[1])"/>
-        <xsl:if test="not(normalize-space(mods:role[1]/mods:roleTerm)='') and name(..) != 'subject'"
-          > (<xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>)</xsl:if>
+        <xsl:for-each select="mods:namePart[normalize-space()!='']">
+          <xsl:value-of select="normalize-space(.)"/>
+          <xsl:if test="position()!=last()">
+            <xsl:text>, </xsl:text>
+          </xsl:if>
+        </xsl:for-each>
+        <!-- <xsl:value-of select="normalize-space(mods:namePart[1])"/> -->
+        <xsl:if test="not(normalize-space(mods:role[1]/mods:roleTerm)='') and name(..) != 'subject'">
+          <xsl:text> (</xsl:text>
+          <xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>
+          <xsl:text>)</xsl:text>
+        </xsl:if>
       </xsl:variable>
       <xsl:variable name="this_prefix">
         <xsl:value-of select="concat($prefix, $field_name)"/>
@@ -176,6 +197,170 @@
       <xsl:with-param name="pid" select="$pid"/>
       <xsl:with-param name="datastream" select="$datastream"/>
     </xsl:call-template>
+  </xsl:template>
+
+  <!-- Custom subject/topic -->
+  <xsl:template match="mods:subject[local-name(*[1])='topic']" mode="slurping_MODS">
+    <xsl:param name="prefix"/>
+    <xsl:param name="suffix"/>
+    <xsl:param name="pid">not provided</xsl:param>
+    <xsl:param name="datastream">not provided</xsl:param>
+
+    <xsl:variable name="subj">
+      <xsl:for-each select="mods:topic[normalize-space()!=''] | mods:geographic[normalize-space()!=''] | mods:temporal[normalize-space()!=''] | mods:occupation[normalize-space()!=''] | mods:genre[normalize-space()!=''] | mods:name[normalize-space()!='']">
+        <xsl:value-of select="normalize-space(.)"/>
+        <xsl:if test="position()!=last()">--</xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="this_prefix">
+      <xsl:value-of select="concat($prefix, 'subject_topic_')"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="normalize-space($subj)"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+
+    <!--
+		<xsl:variable name="firstsubj">
+      <xsl:value-of select="normalize-space(mods:topic[1])"/>
+		</xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="$firstsubj"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+    -->
+  </xsl:template>
+
+  <!-- Custom subject/geographic -->
+  <xsl:template match="mods:subject[local-name(*[1])='geographic']" mode="slurping_MODS">
+    <xsl:param name="prefix"/>
+    <xsl:param name="suffix"/>
+    <xsl:param name="pid">not provided</xsl:param>
+    <xsl:param name="datastream">not provided</xsl:param>
+
+    <xsl:variable name="subj">
+      <xsl:for-each select="mods:topic[normalize-space()!=''] | mods:geographic[normalize-space()!=''] | mods:temporal[normalize-space()!=''] | mods:occupation[normalize-space()!=''] | mods:genre[normalize-space()!=''] | mods:name[normalize-space()!='']">
+        <xsl:value-of select="normalize-space(.)"/>
+        <xsl:if test="position()!=last()">--</xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="this_prefix">
+      <xsl:value-of select="concat($prefix, 'subject_geographic_')"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="normalize-space($subj)"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+
+    <!--
+    <xsl:variable name="firstsubj">
+      <xsl:value-of select="normalize-space(mods:geographic[1])"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="$firstsubj"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+    -->
+  </xsl:template>
+
+  <!-- Custom subject/temporal -->
+  <xsl:template match="mods:subject[local-name(*[1])='temporal']" mode="slurping_MODS">
+    <xsl:param name="prefix"/>
+    <xsl:param name="suffix"/>
+    <xsl:param name="pid">not provided</xsl:param>
+    <xsl:param name="datastream">not provided</xsl:param>
+
+    <xsl:variable name="subj">
+      <xsl:for-each select="mods:topic[normalize-space()!=''] | mods:geographic[normalize-space()!=''] | mods:temporal[normalize-space()!=''] | mods:occupation[normalize-space()!=''] | mods:genre[normalize-space()!=''] | mods:name[normalize-space()!='']">
+        <xsl:value-of select="normalize-space(.)"/>
+        <xsl:if test="position()!=last()">--</xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="this_prefix">
+      <xsl:value-of select="concat($prefix, 'subject_temporal_')"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="normalize-space($subj)"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+
+    <!--
+    <xsl:variable name="firstsubj">
+      <xsl:value-of select="normalize-space(mods:temporal[1])"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="$firstsubj"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+    -->
+  </xsl:template>
+
+  <!-- Custom subject/genre -->
+  <xsl:template match="mods:subject[local-name(*[1])='genre']" mode="slurping_MODS">
+    <xsl:param name="prefix"/>
+    <xsl:param name="suffix"/>
+    <xsl:param name="pid">not provided</xsl:param>
+    <xsl:param name="datastream">not provided</xsl:param>
+
+    <xsl:variable name="subj">
+      <xsl:for-each select="mods:topic[normalize-space()!=''] | mods:geographic[normalize-space()!=''] | mods:temporal[normalize-space()!=''] | mods:occupation[normalize-space()!=''] | mods:genre[normalize-space()!=''] | mods:name[normalize-space()!='']">
+        <xsl:value-of select="normalize-space(.)"/>
+        <xsl:if test="position()!=last()">--</xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="this_prefix">
+      <xsl:value-of select="concat($prefix, 'subject_genre_')"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="normalize-space($subj)"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+
+    <!--
+    <xsl:variable name="firstsubj">
+      <xsl:value-of select="normalize-space(mods:genre[1])"/>
+    </xsl:variable>
+
+    <xsl:call-template name="mods_language_fork">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="$firstsubj"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+    -->
   </xsl:template>
 
   <!-- Handle dates. -->
@@ -455,5 +640,26 @@
       <xsl:with-param name="pid" select="$pid"/>
       <xsl:with-param name="datastream" select="$datastream"/>
     </xsl:apply-templates>
+  </xsl:template>
+
+  <xsl:template name="chopPunctuation">
+    <xsl:param name="chopString"/>
+    <xsl:param name="punctuation">
+      <xsl:text>.:,;/ </xsl:text>
+    </xsl:param>
+    <xsl:variable name="length" select="string-length($chopString)"/>
+    <xsl:choose>
+      <xsl:when test="$length=0"/>
+      <xsl:when test="contains($punctuation, substring($chopString,$length,1))">
+        <xsl:call-template name="chopPunctuation">
+          <xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+          <xsl:with-param name="punctuation" select="$punctuation"/>
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:when test="not($chopString)"/>
+      <xsl:otherwise>
+        <xsl:value-of select="$chopString"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 </xsl:stylesheet>

--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -180,6 +180,7 @@
     <xsl:param name="suffix"/>
     <xsl:param name="pid">not provided</xsl:param>
     <xsl:param name="datastream">not provided</xsl:param>
+
     <xsl:variable name="this_prefix">
       <xsl:value-of select="concat($prefix, 'accessCondition_use_and_reproduction_phs_')"/>
     </xsl:variable>
@@ -193,6 +194,21 @@
       <xsl:with-param name="pid" select="$pid"/>
       <xsl:with-param name="datastream" select="$datastream"/>
     </xsl:call-template>
+
+    <xsl:variable name="this_prefix">
+      <xsl:value-of select="concat($prefix, 'accessCondition_use_and_reproduction_uri_phs_')"/>
+    </xsl:variable>
+    <xsl:variable name="this_value">
+      <xsl:value-of select="normalize-space(@xlink:href)"/>
+    </xsl:variable>
+    <xsl:call-template name="general_mods_field">
+      <xsl:with-param name="prefix" select="$this_prefix"/>
+      <xsl:with-param name="suffix" select="$suffix"/>
+      <xsl:with-param name="value" select="$this_value"/>
+      <xsl:with-param name="pid" select="$pid"/>
+      <xsl:with-param name="datastream" select="$datastream"/>
+    </xsl:call-template>
+
   </xsl:template>
 
   <!-- Custom subject/name -->

--- a/islandora_transforms/slurp_all_MODS_to_solr.xslt
+++ b/islandora_transforms/slurp_all_MODS_to_solr.xslt
@@ -77,6 +77,13 @@
           <xsl:value-of select="normalize-space(mods:role[1]/mods:roleTerm)"/>
           <xsl:text>)</xsl:text>
         </xsl:if>
+        <xsl:if test="../mods:topic[normalize-space()!=''] | ../mods:geographic[normalize-space()!=''] | ../mods:temporal[normalize-space()!=''] | ../mods:occupation[normalize-space()!=''] | ../mods:genre[normalize-space()!='']">
+          <xsl:text>--</xsl:text>
+          <xsl:for-each select="../mods:topic[normalize-space()!=''] | ../mods:geographic[normalize-space()!=''] | ../mods:temporal[normalize-space()!=''] | ../mods:occupation[normalize-space()!=''] | ../mods:genre[normalize-space()!='']">
+            <xsl:value-of select="normalize-space(.)"/>
+            <xsl:if test="position()!=last()">--</xsl:if>
+          </xsl:for-each>
+        </xsl:if>
       </xsl:variable>
       <xsl:variable name="this_prefix">
         <xsl:value-of select="concat($prefix, $field_name)"/>
@@ -188,6 +195,16 @@
     </xsl:call-template>
   </xsl:template>
 
+  <!-- Custom subject/name -->
+  <xsl:template match="mods:subject[local-name(*[1])='name']" mode="slurping_MODS">
+    <xsl:param name="prefix"/>
+    <xsl:param name="suffix"/>
+    <xsl:param name="pid">not provided</xsl:param>
+    <xsl:param name="datastream">not provided</xsl:param>
+
+    <!-- supress subfields of name subject -->
+  </xsl:template>
+  
   <!-- Custom subject/topic -->
   <xsl:template match="mods:subject[local-name(*[1])='topic']" mode="slurping_MODS">
     <xsl:param name="prefix"/>


### PR DESCRIPTION
Previously, all MODS subjects were dumped in one <subject> tag, like so:

```
<subject>
  <topic authority="lcsh">
    Presbyterian Church--Missions--Korea--Educational work.
  </topic>
  <geographic authority="lcsh">
     Korea--History--Allied occupation, 1945-1948.
  </geographic>
  <name type="corporate" authority="lcsh">
    <namePart>
      United Presbyterian Church in the U.S.A. Korea Mission.
    </namePart>
  </name>
  <hierarchicalGeographic>
    <continent>Asia</continent>
    <country>North Korea</country>
  </hierarchicalGeographic>
</subject>
```

The PHS metadata was transformed to split these out into distinct <subject> fields, and future records will utilize the subfields like this:

```
<subject authority="lcsh">
  <topic>Presbyterian Church</topic>
  <topic>Missions</topic>
  <geographic>Korea</geographic>
  <topic>Educational work.</topic>
</subject>
<subject authority="lcsh">
  <geographic>Korea</geographic>
  <topic>History</topic>
  <temporal>Allied occupation, 1945-1948.</temporal>
</subject>
```

The updates to the solr configuration maintain the current display and faceting on the full subject heading. The code takes the subfields and formats them like "Presbyterian Church--Missions--Korea--Educational work." for indexing in solr. 

Additional changes handle <name> fields that are divided into subfields. Previously only the first <namePart> would be indexed. Names are now supported like this:

```
<name type="personal">
  <namePart>Franklin, Benjamin</namePart>
  <namePart type="date">1706-1790</namePart>
  <role>
    <roleTerm>creator</roleTerm>
  </role>
</name>
```

or even

```
<name type="personal">
  <namePart type="family">Franklin</namePart>
  <namePart type="given">Benjamin</namePart>
  <namePart type="date">1706-1790.</namePart>
  <role>
    <roleTerm>creator</roleTerm>
  </role>
</name>
```

Name subjects can also now have topic subdivisions, which were previously not included in the index field.

```
<subject>
  <name type="personal">
    <namePart type="family">Franklin</namePart>
    <namePart type="given">Benjamin</namePart>
    <namePart type="date">1706-1790.</namePart>
    <role>
      <roleTerm>creator</roleTerm>
    </role>
  </name>
  <topic>Archives</topic>
</subject>
```

Additional minor changes add a new `mods_accessCondition_use_and_reproduction_uri_phs_ms` solr field that is the `xlink:href` attribute from the `<mods:accessRights "use and reproduction">` tag.
